### PR TITLE
Setting "normalize" parameter to True on the Get All Available Forecasts route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,5 @@ services:
     ports:
       - 80:80
     environment:
-      - DB_URL=postgresql://postgres:postgres@postgres_forecast:5432/postgres
-      - DB_URL_PV=postgresql://postgres:postgres@postgres_forecast:5432/postgres
+      - DB_URL=sqlite:///test.db
+      - DB_URL_PV=sqlite:///test.db

--- a/src/database.py
+++ b/src/database.py
@@ -45,7 +45,7 @@ def get_latest_status_from_database(session: Session) -> Status:
 def get_forecasts_from_database(
     session: Session, historic: Optional[bool] = False
 ) -> ManyForecasts:
-    """Get forecasts from database for all GSPs"""
+    """# Get forecasts from database for all GSPs"""
     # get the latest forecast for all gsps.
 
     if historic:

--- a/src/database.py
+++ b/src/database.py
@@ -45,7 +45,7 @@ def get_latest_status_from_database(session: Session) -> Status:
 def get_forecasts_from_database(
     session: Session, historic: Optional[bool] = False
 ) -> ManyForecasts:
-    """# Get forecasts from database for all GSPs"""
+    """Get forecasts from database for all GSPs"""
     # get the latest forecast for all gsps.
 
     if historic:
@@ -86,7 +86,7 @@ def get_forecasts_from_database(
 def get_forecasts_for_a_specific_gsp_from_database(
     session: Session, gsp_id, historic: Optional[bool] = False
 ) -> Forecast:
-    """Get forecasts for on GSP from database"""
+    """Get forecasts for one GSP from database"""
 
     yesterday_start_datetime = datetime.now(tz=timezone.utc).date() - timedelta(days=1)
     yesterday_start_datetime = datetime.combine(yesterday_start_datetime, datetime.min.time())

--- a/src/database.py
+++ b/src/database.py
@@ -110,8 +110,7 @@ def get_forecasts_for_a_specific_gsp_from_database(
 def get_latest_forecast_values_for_a_specific_gsp_from_database(
     session: Session, gsp_id: int, forecast_horizon_minutes: Optional[int] = None
 ) -> List[ForecastValue]:
-    """
-    Get the forecast values for yesterday and today for one gsp
+    """Get the forecast values for yesterday and today for one gsp
 
     :param session: sqlalchemy session
     :param gsp_id: gsp id, 0 is national
@@ -166,8 +165,7 @@ def get_latest_national_forecast_from_database(session: Session) -> Forecast:
 def get_truth_values_for_a_specific_gsp_from_database(
     session: Session, gsp_id: int, regime: Optional[str] = "in-day"
 ) -> List[GSPYield]:
-    """
-    Get the truth value for one gsp for yesterday and today
+    """Get the truth value for one gsp for yesterday and today
 
     :param session: sql session
     :param gsp_id: gsp id
@@ -187,8 +185,7 @@ def get_truth_values_for_a_specific_gsp_from_database(
 
 
 def get_gsp_system(session: Session, gsp_id: Optional[int] = None) -> List[Location]:
-    """
-    Get gsp system details
+    """Get gsp system details
 
     :param session:
     :param gsp_id: optional input. If None, get all systems

--- a/src/database.py
+++ b/src/database.py
@@ -1,4 +1,5 @@
 """ Functions to read from the database and format """
+from locale import normalize
 import logging
 import os
 from datetime import datetime, timedelta, timezone
@@ -49,7 +50,7 @@ def get_forecasts_from_database(
     # get the latest forecast for all gsps.
 
     if historic:
-
+        
         # get at most 2 days of data.
         yesterday_start_datetime = datetime.now(tz=timezone.utc).date() - timedelta(days=1)
         yesterday_start_datetime = datetime.combine(yesterday_start_datetime, datetime.min.time())
@@ -59,6 +60,7 @@ def get_forecasts_from_database(
             start_target_time=yesterday_start_datetime,
             preload_children=True,
             historic=True,
+            normalize=True,
         )
     else:
         # To speed up read time we only look at the last 12 hours of results, and take floor 30 mins
@@ -71,6 +73,7 @@ def get_forecasts_from_database(
             start_created_utc=yesterday_start_datetime,
             start_target_time=yesterday_start_datetime,
             preload_children=True,
+            normalize=True,
         )
 
     # change to pydantic objects

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -47,12 +47,12 @@ async def get_forecasts_for_a_specific_gsp(
     historic: Optional[bool] = False,
 ) -> Forecast:
     """### Get one forecast for a specific GSP using
-    
+
     The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts)
     for the upcoming 8 hours at every 30-minute interval (targetTime). Setting history to true on this route
-    will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP. 
+    will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP.
 
-    
+
     #### Parameters
     - gsp_id: gsp_id of the desired forecast
     - historic: set to true to get the previous day's forecasts and false for just today's forecast
@@ -76,11 +76,11 @@ async def get_latest_forecasts_for_a_specific_gsp(
     """### Gets the latest forecasts for a specific GSP for today and yesterday
 
     This route returns a simplified forecast object with only targetTimes and
-    expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for the given GSP. 
+    expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for the given GSP.
     The __forecast_horizon_minutes__ parameter can be used to retrieves the latest forecast a given set of
-    minutes before the target time. 
+    minutes before the target time.
 
-    #### Parameters    
+    #### Parameters
     - gsp_id: gsp_id of the requested forecast
     - forecast_horizon_minutes: optional forecast horizon in minutes (ex. 35 returns
     the latest forecast made 35 minutes before the target time)
@@ -100,21 +100,21 @@ async def get_truths_for_a_specific_gsp(
     """### Get PV_Live values for a specific GSP for yesterday and today
 
     PV_Live is Sheffield's API that pulls live PV data. Check out [Sheffield Solar PV_Live](https://www.solar
-    sheffield.ac.uk/pvlive/) for more details. 
+    sheffield.ac.uk/pvlive/) for more details.
 
     The OCF Forecast is trying to predict the PV_Live 'day-after' value.
-    
+
     This route has the __regime__ parameter that lets you look at values __in-day__ or __day-after__, which
     includes updated values that are calculated around midnight when more data is available. __Day-after__
     values are updated i__in-day__ values. __In-day__ gives you all the readings from the day before up to the
     most recent reported gsp yield. __Day_after__ reports all the readings from the previous day. For example,
     a day-after regime request made on 08/09/2022 returns updated gsp yield for 07/09/2022. The 08/09/2022
-    __day-after__ values then become available at midnight on 09/09/2022. 
-    
-    If regime is not specificied, the most up-to-date gsp yield is returned. 
+    __day-after__ values then become available at midnight on 09/09/2022.
+
+    If regime is not specificied, the most up-to-date gsp yield is returned.
 
 
-    #### Parameters    
+    #### Parameters
     - gsp_id: gsp_id of the requested forecast
     - regime: can choose __in-day__ or __day-after__
 
@@ -136,13 +136,13 @@ async def get_all_available_forecasts(
     """### Get the latest information for all available forecasts for all GSP's
 
     This route returns forecasts from all available GSP's with an option to normalize the forecasts by GSP
-    installed capacity (installedCapacityMw). 
+    installed capacity (installedCapacityMw).
 
-    There is also the option to pull forecast history from yesterday. 
+    There is also the option to pull forecast history from yesterday.
 
 
-    #### Parameters    
-    - normalize: boolean based on forecasts by GSP installed megawatt capacity 
+    #### Parameters
+    - normalize: boolean based on forecasts by GSP installed megawatt capacity
     - historic: boolean => TRUE returns the forecasts of yesterday along with today's forecasts
     """
 
@@ -160,11 +160,11 @@ async def get_all_available_forecasts(
 
 @router.get("/forecast/national", response_model=Forecast)
 async def get_nationally_aggregated_forecasts(session: Session = Depends(get_session)) -> Forecast:
-    """### Returns a national aggregate solar PV energy forecast 
-    
+    """### Returns a national aggregate solar PV energy forecast
+
     This route aggregrates data from all GSP forecasts and creates a 6-7 hour nowcast of national solar PV
-    energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget). 
-    
+    energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget).
+
     """
 
     logger.debug("Get national forecasts")
@@ -173,7 +173,7 @@ async def get_nationally_aggregated_forecasts(session: Session = Depends(get_ses
 
 @router.get("/gsp_boundaries")
 async def get_gsp_boundaries() -> dict:
-    """### Get one GSP boundary for a specific GSP 
+    """### Get one GSP boundary for a specific GSP
 
     This route is still under construction...
 
@@ -197,20 +197,20 @@ async def get_systems(
 ) -> List[Location]:
     """### Get system details for a single GSP or all GSP's
 
-    Returns an object with the system details of a given GSP using the gsp_id parameter. 
-    This object is the same as the initial object returned by the 
-    __Get Forecasts for a Specific GSP__ request. 
-    
+    Returns an object with the system details of a given GSP using the gsp_id parameter.
+    This object is the same as the initial object returned by the
+    __Get Forecasts for a Specific GSP__ request.
+
     Provide one gsp_id to return system details for that GSP, otherwise details for ALL grid systems will be
-    returned. 
+    returned.
 
     #### Parameters
     - gsp_id: gsp_id of the requested system
-    - NB: If no parameter is entered, system details for all 300+ GSP's are returned. 
+    - NB: If no parameter is entered, system details for all 300+ GSP's are returned.
 
     #### Metadata
     - label
-    - gspId 
+    - gspId
     - gspName
     - gspGroup
     - regtionName

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -47,16 +47,14 @@ async def get_forecasts_for_a_specific_gsp(
     historic: Optional[bool] = False,
 ) -> Forecast:
     """
-    ### Get one forecast for a specific GSP with gsp_id.
+    ### Get one forecast for a specific GSP using
     
     The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts) for the next 6-7 hours at every 30-minute interval (targetTime). Setting history to true on this route will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP. 
 
     
-    (below is info from the original description)
-    - gsp_id: The gsp id of the forecast you want
-    - session: sql session (this is done automatically)
-    - historic: There is an option to get historic forecast also.
-    - Forecast object
+    #### Parameters
+    - gsp_id: gsp_id of the desired forecast
+    - historic: set to true to get the previous day's forecasts and false for just today's forecast
     """
 
     logger.info(f"Get forecasts for gsp id {gsp_id} with {historic=}")
@@ -74,12 +72,15 @@ async def get_latest_forecasts_for_a_specific_gsp(
     session: Session = Depends(get_session),
     forecast_horizon_minutes: Optional[int] = None,
 ) -> List[ForecastValue]:
-    """Get the latest forecasts for a specific GSP id for today and yesterday
+    """### Gets the latest forecasts for a specific GSP for today and yesterday
 
-    :param gsp_id: The gsp id of the forecast you want
-    :param session: sql session (this is done automatically)
-    :param forecast_horizon_minutes: Optional forecast horizon in minutes. I.e 35 minutes, means
-        get the latest forecast made 35 minutes before the target time.
+    This route returns a simplified forecast object with only targetTimes and expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for the given GSP. 
+    The __forecast_horizon_minutes__ parameter can be used to retrieves the latest forecast a given set of minutes before the target time. 
+
+    #### Parameters    
+    - gsp_id: gsp_id of the requested forecast
+    - forecast_horizon_minutes: optional forecast horizon in minutes (ex. 35 returns
+    the latest forecast made 35 minutes before the target time)
     """
 
     logger.info(f"Get forecasts for gsp id {gsp_id} with {forecast_horizon_minutes=}")
@@ -93,13 +94,27 @@ async def get_latest_forecasts_for_a_specific_gsp(
 async def get_truths_for_a_specific_gsp(
     gsp_id: int, regime: Optional[str] = None, session: Session = Depends(get_session)
 ) -> List[GSPYield]:
-    """Get PV live values for a specific GSP id, for yesterday and today
-    See [Sheffield Solar PV_Live](https://www.solar.sheffield.ac.uk/pvlive/) for more details.
-    Regime can "in-day" or "day-after",
-    as new values are calculated around midnight when more data is available.
-    If regime is not specific, the latest gsp yield is loaded.
 
-    The OCF Forecast is trying to predict the PV live 'day-after' value.
+    """### Get PV_Live values for a specific GSP for yesterday and today
+
+    PV_Live is Sheffield's API that pulls live PV data. Check out [Sheffield Solar PV_Live](https://www.solar.sheffield.ac.uk/pvlive/) for more details. 
+
+    The OCF Forecast is trying to predict the PV_Live 'day-after' value.
+    
+    This route has the __regime__ parameter that lets you look at values __in-day__ or __day-after__, which includes updated values that are calculated around midnight when more data is available. __Day-after__ values are updated i__in-day__ values. __In-day__ gives you all the readings from the day before up to the most recent reported gsp yield. __Day_after__ reports all the readings from the previous day. For example, a day-after regime request made on 08/09/2022 returns updated gsp yield for 07/09/2022. The 08/09/2022 __day-after__ values then become available at midnight on 09/09/2022. 
+    
+    If regime is not specificied, the most up-to-date gsp yield is returned. 
+
+
+    #### Parameters    
+    - gsp_id: gsp_id of the requested forecast
+    - regime: can choose __in-day__ or __day-after__
+
+    #### Metadata 
+    - datetimeUtc
+    - solarGenerationKw
+    - regime
+    - gsp
     """
 
     logger.info(f"Get PV Live estimates values for gsp id {gsp_id} and regime {regime}")
@@ -115,11 +130,16 @@ async def get_all_available_forecasts(
     historic: Optional[bool] = False,
     session: Session = Depends(get_session),
 ) -> ManyForecasts:
-    """Get the latest information for all available forecasts
+    """### Get the latest information for all available forecasts for all GSP's
 
-    There is an option to normalize the forecasts by gsp capacity
-    There is also an option to pull historic data.
-        This will the load the latest forecast value for each target time.
+    This route returns forecasts from all available GSP's with an option to normalize the forecasts by GSP installed capacity (installedCapacityMw). 
+
+    There is also the option to pull forecast history from yesterday. 
+
+
+    #### Parameters    
+    - normalize: boolean based on forecasts by GSP installed megawatt capacity 
+    - historic: boolean => TRUE returns the forecasts of yesterday along with today's forecasts
     """
 
     logger.info(f"Get forecasts for all gsps. The options are  {normalize=} and {historic=}")
@@ -136,7 +156,11 @@ async def get_all_available_forecasts(
 
 @router.get("/forecast/national", response_model=Forecast)
 async def get_nationally_aggregated_forecasts(session: Session = Depends(get_session)) -> Forecast:
-    """Get an aggregated forecast at the national level"""
+    """### Returns a national aggregate solar PV energy forecast 
+    
+    This route aggregrates data from all GSP forecasts and creates a 6-7 hour nowcast of national solar PV energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget). 
+    
+    """
 
     logger.debug("Get national forecasts")
     return get_latest_national_forecast_from_database(session=session)
@@ -144,12 +168,14 @@ async def get_nationally_aggregated_forecasts(session: Session = Depends(get_ses
 
 @router.get("/gsp_boundaries")
 async def get_gsp_boundaries() -> dict:
-    """Get one gsp boundary for a specific GSP id
+    """### Get one GSP boundary for a specific GSP 
 
-    This is a wrapper around the dataset in
-    'https://data.nationalgrideso.com/system/gis-boundaries-for-gb-grid-supply-points'
+    This route is still under construction...
 
-    The returned object is in EPSG:4326 i.e latitude and longitude
+    [This is a wrapper around the dataset](https://data.nationalgrideso.com/system/gis-boundaries-for-gb-grid-supply-points).
+
+    Returns an object that is in EPSG:4326 (ie. latitude & longitude coordinates)
+
     """
 
     logger.info("Getting all GSP boundaries")
@@ -166,9 +192,24 @@ async def get_systems(
     session: Session = Depends(get_session), gsp_id: Optional[int] = None
 ) -> List[Location]:
     """
-    Get gsp system details.
+    ### Get system details for a single GSP or all GSP's
 
-    Provide gsp_id to just return one gsp system, otherwise all are returned
+    Returns an object with the system details of a given GSP using the gsp_id parameter. This object is the same as the initial object returned by the __Get Forecasts for a Specific GSP__ request. 
+    
+    Provide one gsp_id to return system details for that GSP, otherwise details for ALL grid systems will be returned. 
+
+    #### Parameters
+    - gsp_id: gsp_id of the requested system
+    - NB: If no parameter is entered, system details for all 300+ GSP's are returned. 
+
+    #### Metadata
+    - label
+    - gspId 
+    - gspName
+    - gspGroup
+    - regtionName
+    - installedCapacityMw
+    - rmMode
     """
 
     logger.info(f"Get GSP systems for {gsp_id=}")

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -48,14 +48,17 @@ async def get_forecasts_for_a_specific_gsp(
 ) -> Forecast:
     """### Get one forecast for a specific GSP using
 
-    The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts)
-    for the upcoming 8 hours at every 30-minute interval (targetTime). Setting history to true on this route
-    will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP.
+    The forecast object is returned with the expected megawatt generation 
+    (expectedPowerGenerationMegawatts) for the upcoming 8 hours at every 
+    30-minute interval (targetTime). Setting history to true on this route
+    will return targetTime and expectedPowerGenerationMegawatt readings from 
+    the day before for the given GSP.
 
 
     #### Parameters
     - gsp_id: gsp_id of the desired forecast
-    - historic: set to true to get the previous day's forecasts and false for just today's forecast
+    - historic: set to true to get the previous day's forecasts and false 
+    for just today's forecast
     """
 
     logger.info(f"Get forecasts for gsp id {gsp_id} with {historic=}")
@@ -76,9 +79,9 @@ async def get_latest_forecasts_for_a_specific_gsp(
     """### Gets the latest forecasts for a specific GSP for today and yesterday
 
     This route returns a simplified forecast object with only targetTimes and
-    expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for the given GSP.
-    The __forecast_horizon_minutes__ parameter can be used to retrieves the latest forecast a given set of
-    minutes before the target time.
+    expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for 
+    the given GSP. The __forecast_horizon_minutes__ parameter can be used to 
+    retrieves the latest forecast a given set of minutes before the target time.
 
     #### Parameters
     - gsp_id: gsp_id of the requested forecast
@@ -104,20 +107,20 @@ async def get_truths_for_a_specific_gsp(
 
     The OCF Forecast is trying to predict the PV_Live 'day-after' value.
 
-    This route has the __regime__ parameter that lets you look at values __in-day__ or __day-after__, which
-    includes updated values that are calculated around midnight when more data is available. __Day-after__
-    values are updated i__in-day__ values. __In-day__ gives you all the readings from the day before up to the
-    most recent reported gsp yield. __Day_after__ reports all the readings from the previous day. For example,
-    a day-after regime request made on 08/09/2022 returns updated gsp yield for 07/09/2022. The 08/09/2022
-    __day-after__ values then become available at midnight on 09/09/2022.
+    This route has the __regime__ parameter that lets you look at values __in-day__ or 
+    __day-after__, which includes updated values that are calculated around 10am the day 
+    after when more data is available. __Day-after__ values are updated i__in-day__ values. 
+    __In-day__ gives you all the readings from the day before up to the most recent 
+    reported gsp yield. __Day_after__ reports all the readings from the previous day. 
+    For example, a day-after regime request made on 08/09/2022 returns updated gsp yield 
+    for 07/09/2022. The 08/09/2022 __day-after__ values then become available at 10am 
+    on 09/09/2022.
 
-    If regime is not specificied, the most up-to-date gsp yield is returned.
-
+    If regime is not specificied, the most up-to-date GSP yield is returned.
 
     #### Parameters
     - gsp_id: gsp_id of the requested forecast
     - regime: can choose __in-day__ or __day-after__
-
     """
 
     logger.info(f"Get PV Live estimates values for gsp id {gsp_id} and regime {regime}")
@@ -135,8 +138,8 @@ async def get_all_available_forecasts(
 ) -> ManyForecasts:
     """### Get the latest information for all available forecasts for all GSP's
 
-    This route returns forecasts from all available GSP's with an option to normalize the forecasts by GSP
-    installed capacity (installedCapacityMw).
+    This route returns forecasts from all available GSP's with an option to normalize 
+    the forecasts by GSP installed capacity (installedCapacityMw).
 
     There is also the option to pull forecast history from yesterday.
 
@@ -159,10 +162,11 @@ async def get_all_available_forecasts(
 
 
 @router.get("/forecast/national", response_model=Forecast)
-async def get_nationally_aggregated_forecasts(session: Session = Depends(get_session)) -> Forecast:
+async def get_nationally_aggregated_forecasts(session: Session = Depends(get_session)
+) -> Forecast:
     """### Returns a national aggregate solar PV energy forecast
 
-    This route aggregrates data from all GSP forecasts and creates a 6-7 hour nowcast of national solar PV
+    This route aggregrates data from all GSP forecasts and creates 8-hour nowcast of national solar PV
     energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget).
 
     """
@@ -177,7 +181,8 @@ async def get_gsp_boundaries() -> dict:
 
     This route is still under construction...
 
-    [This is a wrapper around the dataset](https://data.nationalgrideso.com/system/gis-boundaries-for-gb-grid-supply-points).
+    [This is a wrapper around the dataset](https://data.nationalgrideso.com/system
+    gis-boundaries-for-gb-grid-supply-points).
 
     Returns an object that is in EPSG:4326 (ie. latitude & longitude coordinates)
     """

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -102,8 +102,10 @@ async def get_truths_for_a_specific_gsp(
 ) -> List[GSPYield]:
     """### Get PV_Live values for a specific GSP for yesterday and today
 
-    PV_Live is Sheffield's API that pulls live PV data. Check out [Sheffield Solar PV_Live](https://www.solar
-    sheffield.ac.uk/pvlive/) for more details.
+    PV_Live is Sheffield's API that pulls live PV data. 
+    
+    Check out [Sheffield Solar PV_Live](https://www.solarsheffield.ac.uk/pvlive/) for 
+    more details.
 
     The OCF Forecast is trying to predict the PV_Live 'day-after' value.
 
@@ -202,12 +204,14 @@ async def get_systems(
 ) -> List[Location]:
     """### Get system details for a single GSP or all GSP's
 
-    Returns an object with the system details of a given GSP using the gsp_id parameter.
-    This object is the same as the initial object returned by the
-    __Get Forecasts for a Specific GSP__ request.
+    Returns an object with the system details of a given GSP using the 
+    gsp_id parameter.
+    
+    This object is the same as the initial object returned 
+    by the __Get Forecasts for a Specific GSP__ request.
 
-    Provide one gsp_id to return system details for that GSP, otherwise details for ALL grid systems will be
-    returned.
+    Provide one gsp_id to return system details for that GSP, otherwise details for ALL 
+    grid systems will be returned.
 
     #### Parameters
     - gsp_id: gsp_id of the requested system

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -46,8 +46,7 @@ async def get_forecasts_for_a_specific_gsp(
     session: Session = Depends(get_session),
     historic: Optional[bool] = False,
 ) -> Forecast:
-    """
-    ### Get one forecast for a specific GSP using
+    """### Get one forecast for a specific GSP using
     
     The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts) for the next 6-7 hours at every 30-minute interval (targetTime). Setting history to true on this route will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP. 
 
@@ -174,7 +173,6 @@ async def get_gsp_boundaries() -> dict:
     [This is a wrapper around the dataset](https://data.nationalgrideso.com/system/gis-boundaries-for-gb-grid-supply-points).
 
     Returns an object that is in EPSG:4326 (ie. latitude & longitude coordinates)
-
     """
 
     logger.info("Getting all GSP boundaries")
@@ -190,8 +188,7 @@ async def get_gsp_boundaries() -> dict:
 async def get_systems(
     session: Session = Depends(get_session), gsp_id: Optional[int] = None
 ) -> List[Location]:
-    """
-    ### Get system details for a single GSP or all GSP's
+    """### Get system details for a single GSP or all GSP's
 
     Returns an object with the system details of a given GSP using the gsp_id parameter. This object is the same as the initial object returned by the __Get Forecasts for a Specific GSP__ request. 
     

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -48,7 +48,9 @@ async def get_forecasts_for_a_specific_gsp(
 ) -> Forecast:
     """### Get one forecast for a specific GSP using
     
-    The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts) for the next 6-7 hours at every 30-minute interval (targetTime). Setting history to true on this route will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP. 
+    The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts)
+    for the upcoming 8 hours at every 30-minute interval (targetTime). Setting history to true on this route
+    will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP. 
 
     
     #### Parameters
@@ -73,8 +75,10 @@ async def get_latest_forecasts_for_a_specific_gsp(
 ) -> List[ForecastValue]:
     """### Gets the latest forecasts for a specific GSP for today and yesterday
 
-    This route returns a simplified forecast object with only targetTimes and expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for the given GSP. 
-    The __forecast_horizon_minutes__ parameter can be used to retrieves the latest forecast a given set of minutes before the target time. 
+    This route returns a simplified forecast object with only targetTimes and
+    expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for the given GSP. 
+    The __forecast_horizon_minutes__ parameter can be used to retrieves the latest forecast a given set of
+    minutes before the target time. 
 
     #### Parameters    
     - gsp_id: gsp_id of the requested forecast
@@ -95,11 +99,17 @@ async def get_truths_for_a_specific_gsp(
 ) -> List[GSPYield]:
     """### Get PV_Live values for a specific GSP for yesterday and today
 
-    PV_Live is Sheffield's API that pulls live PV data. Check out [Sheffield Solar PV_Live](https://www.solar.sheffield.ac.uk/pvlive/) for more details. 
+    PV_Live is Sheffield's API that pulls live PV data. Check out [Sheffield Solar PV_Live](https://www.solar
+    sheffield.ac.uk/pvlive/) for more details. 
 
     The OCF Forecast is trying to predict the PV_Live 'day-after' value.
     
-    This route has the __regime__ parameter that lets you look at values __in-day__ or __day-after__, which includes updated values that are calculated around midnight when more data is available. __Day-after__ values are updated i__in-day__ values. __In-day__ gives you all the readings from the day before up to the most recent reported gsp yield. __Day_after__ reports all the readings from the previous day. For example, a day-after regime request made on 08/09/2022 returns updated gsp yield for 07/09/2022. The 08/09/2022 __day-after__ values then become available at midnight on 09/09/2022. 
+    This route has the __regime__ parameter that lets you look at values __in-day__ or __day-after__, which
+    includes updated values that are calculated around midnight when more data is available. __Day-after__
+    values are updated i__in-day__ values. __In-day__ gives you all the readings from the day before up to the
+    most recent reported gsp yield. __Day_after__ reports all the readings from the previous day. For example,
+    a day-after regime request made on 08/09/2022 returns updated gsp yield for 07/09/2022. The 08/09/2022
+    __day-after__ values then become available at midnight on 09/09/2022. 
     
     If regime is not specificied, the most up-to-date gsp yield is returned. 
 
@@ -108,11 +118,6 @@ async def get_truths_for_a_specific_gsp(
     - gsp_id: gsp_id of the requested forecast
     - regime: can choose __in-day__ or __day-after__
 
-    #### Metadata 
-    - datetimeUtc
-    - solarGenerationKw
-    - regime
-    - gsp
     """
 
     logger.info(f"Get PV Live estimates values for gsp id {gsp_id} and regime {regime}")
@@ -130,7 +135,8 @@ async def get_all_available_forecasts(
 ) -> ManyForecasts:
     """### Get the latest information for all available forecasts for all GSP's
 
-    This route returns forecasts from all available GSP's with an option to normalize the forecasts by GSP installed capacity (installedCapacityMw). 
+    This route returns forecasts from all available GSP's with an option to normalize the forecasts by GSP
+    installed capacity (installedCapacityMw). 
 
     There is also the option to pull forecast history from yesterday. 
 
@@ -156,7 +162,8 @@ async def get_all_available_forecasts(
 async def get_nationally_aggregated_forecasts(session: Session = Depends(get_session)) -> Forecast:
     """### Returns a national aggregate solar PV energy forecast 
     
-    This route aggregrates data from all GSP forecasts and creates a 6-7 hour nowcast of national solar PV energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget). 
+    This route aggregrates data from all GSP forecasts and creates a 6-7 hour nowcast of national solar PV
+    energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget). 
     
     """
 
@@ -190,9 +197,12 @@ async def get_systems(
 ) -> List[Location]:
     """### Get system details for a single GSP or all GSP's
 
-    Returns an object with the system details of a given GSP using the gsp_id parameter. This object is the same as the initial object returned by the __Get Forecasts for a Specific GSP__ request. 
+    Returns an object with the system details of a given GSP using the gsp_id parameter. 
+    This object is the same as the initial object returned by the 
+    __Get Forecasts for a Specific GSP__ request. 
     
-    Provide one gsp_id to return system details for that GSP, otherwise details for ALL grid systems will be returned. 
+    Provide one gsp_id to return system details for that GSP, otherwise details for ALL grid systems will be
+    returned. 
 
     #### Parameters
     - gsp_id: gsp_id of the requested system

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -47,9 +47,12 @@ async def get_forecasts_for_a_specific_gsp(
     historic: Optional[bool] = False,
 ) -> Forecast:
     """
-    # Get one forecast for a specific GSP id.
-    ### Get the PV forecast for each target time (30-minute intervals) for yesterday and today.
-    ## Metadata for the forecast object:
+    ### Get one forecast for a specific GSP with gsp_id.
+    
+    The forecast object is returned with the expected megawatt generation (expectedPowerGenerationMegawatts) for the next 6-7 hours at every 30-minute interval (targetTime). Setting history to true on this route will return targetTime and expectedPowerGenerationMegawatt readings from the day before for the given GSP. 
+
+    
+    (below is info from the original description)
     - gsp_id: The gsp id of the forecast you want
     - session: sql session (this is done automatically)
     - historic: There is an option to get historic forecast also.

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -142,7 +142,7 @@ async def get_truths_for_a_specific_gsp(
 
 @router.get("/forecast/all", response_model=ManyForecasts)
 async def get_all_available_forecasts(
-    normalize: Optional[bool] = False,
+    # normalize: Optional[bool] = True,
     historic: Optional[bool] = False,
     session: Session = Depends(get_session),
 ) -> ManyForecasts:
@@ -162,7 +162,7 @@ async def get_all_available_forecasts(
 
 
     #### Parameters
-    - normalize: boolean => TRUE returns a value for _expectedPowerGenerationNormalized__, which in decimals is the percent of __installedCapacityMw__ (installed PV megawatt capacity) being forecasted / FALSE returns "null"
+    - normalize: boolean => TRUE returns a value for __expectedPowerGenerationNormalized__, which in decimals is the percent of __installedCapacityMw__ (installed PV megawatt capacity) being forecasted / FALSE returns "null"
     - historic: boolean => TRUE returns the forecasts of yesterday along with today's forecasts for all GSPs
     """
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -94,7 +94,6 @@ async def get_latest_forecasts_for_a_specific_gsp(
 async def get_truths_for_a_specific_gsp(
     gsp_id: int, regime: Optional[str] = None, session: Session = Depends(get_session)
 ) -> List[GSPYield]:
-
     """### Get PV_Live values for a specific GSP for yesterday and today
 
     PV_Live is Sheffield's API that pulls live PV data. Check out [Sheffield Solar PV_Live](https://www.solar.sheffield.ac.uk/pvlive/) for more details. 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -148,7 +148,9 @@ async def get_all_available_forecasts(
 ) -> ManyForecasts:
     """### Get the latest information for ALL available forecasts for ALL GSPs
 
-    The return object contains a forecast object and system details for all National Grid GSPs. 
+    The return object contains a forecast object with system details for all National Grid GSPs. 
+
+    See __Forecast__ and __ForecastValue__ schema for metadata details. 
     
     This request may take a longer time to load because a lot of data is being pulled from the database.
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -47,14 +47,13 @@ async def get_forecasts_for_a_specific_gsp(
     historic: Optional[bool] = False,
 ) -> Forecast:
     """
-    Get one forecast for a specific GSP id.
-
-     This gets the latest forecast for each target time for yesterday and toady.
-
-    :param gsp_id: The gsp id of the forecast you want
-    :param session: sql session (this is done automatically)
-    :param historic: There is an option to get historic forecast also.
-    :return: Forecast object
+    # Get one forecast for a specific GSP id.
+    ### Get the PV forecast for each target time (30-minute intervals) for yesterday and today.
+    ## Metadata for the forecast object:
+    - gsp_id: The gsp id of the forecast you want
+    - session: sql session (this is done automatically)
+    - historic: There is an option to get historic forecast also.
+    - Forecast object
     """
 
     logger.info(f"Get forecasts for gsp id {gsp_id} with {historic=}")
@@ -92,8 +91,7 @@ async def get_truths_for_a_specific_gsp(
     gsp_id: int, regime: Optional[str] = None, session: Session = Depends(get_session)
 ) -> List[GSPYield]:
     """Get PV live values for a specific GSP id, for yesterday and today
-
-    See https://www.solar.sheffield.ac.uk/pvlive/ for more details.
+    See [Sheffield Solar PV_Live](https://www.solar.sheffield.ac.uk/pvlive/) for more details.
     Regime can "in-day" or "day-after",
     as new values are calculated around midnight when more data is available.
     If regime is not specific, the latest gsp yield is loaded.

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -46,19 +46,19 @@ async def get_forecasts_for_a_specific_gsp(
     session: Session = Depends(get_session),
     historic: Optional[bool] = False,
 ) -> Forecast:
-    """### Get one forecast for a specific GSP using
+    """### Get one forecast for a specific GSP 
 
-    The forecast object is returned with the expected megawatt generation 
-    (expectedPowerGenerationMegawatts) for the upcoming 8 hours at every 
-    30-minute interval (targetTime). Setting history to true on this route
-    will return targetTime and expectedPowerGenerationMegawatt readings from 
-    the day before for the given GSP.
+    The return object is a solar forecast with GSP system details. 
 
+    The forecast object is returned with expected megawatt generation at a specific GSP
+    for the upcoming 8 hours at every 30-minute interval (targetTime). 
+    Setting history to TRUE on this route will return readings from yesterday and today for the given GSP.
+
+    Please refer to the __Forecast__ and __ForecastValue__ schemas below for metadata definitions.
 
     #### Parameters
     - gsp_id: gsp_id of the desired forecast
-    - historic: set to true to get the previous day's forecasts and false 
-    for just today's forecast
+    - historic: boolean => TRUE returns yesterday's forecasts in addition to today's forecast
     """
 
     logger.info(f"Get forecasts for gsp id {gsp_id} with {historic=}")
@@ -78,10 +78,14 @@ async def get_latest_forecasts_for_a_specific_gsp(
 ) -> List[ForecastValue]:
     """### Gets the latest forecasts for a specific GSP for today and yesterday
 
-    This route returns a simplified forecast object with only targetTimes and
-    expectedPowerGenerationMegawattsin megawatts at 30-minute intervals for 
-    the given GSP. The __forecast_horizon_minutes__ parameter can be used to 
+    The object returned is a solar forecast for the GSP without GSP system details. 
+
+    This route returns a simplified forecast object with __targetTimes__ and
+    __expectedPowerGenerationMegawatts__ at 30-minute intervals for 
+    the given GSP. The __forecast_horizon_minutes__ parameter
     retrieves the latest forecast a given set of minutes before the target time.
+
+    Please see the __ForecastValue__ schema below for full metadata details. 
 
     #### Parameters
     - gsp_id: gsp_id of the requested forecast
@@ -102,7 +106,12 @@ async def get_truths_for_a_specific_gsp(
 ) -> List[GSPYield]:
     """### Get PV_Live values for a specific GSP for yesterday and today
 
-    PV_Live is Sheffield's API that pulls live PV data. 
+    The return object is a series of real-time solar energy generation readings from PV_Live.
+ 
+    PV_Live is Sheffield's API that reports real-time PV data. These readings are updated throughout
+    the day, reporting the most accurate finalized readings the following day at 10:00 UTC. 
+
+    See the __GSPYield__ schema for metadata details. 
     
     Check out [Sheffield Solar PV_Live](https://www.solarsheffield.ac.uk/pvlive/) for 
     more details.
@@ -110,12 +119,11 @@ async def get_truths_for_a_specific_gsp(
     The OCF Forecast is trying to predict the PV_Live 'day-after' value.
 
     This route has the __regime__ parameter that lets you look at values __in-day__ or 
-    __day-after__, which includes updated values that are calculated around 10am the day 
-    after when more data is available. __Day-after__ values are updated i__in-day__ values. 
+    __day-after__(most accurate reading). __Day-after__ values are updated __in-day__ values. 
     __In-day__ gives you all the readings from the day before up to the most recent 
-    reported gsp yield. __Day_after__ reports all the readings from the previous day. 
-    For example, a day-after regime request made on 08/09/2022 returns updated gsp yield 
-    for 07/09/2022. The 08/09/2022 __day-after__ values then become available at 10am 
+    reported GSP yield. __Day_after__ reports all the readings from the previous day. 
+    For example, a day-after regime request made on 08/09/2022 returns updated GSP yield 
+    for 07/09/2022. The 08/09/2022 __day-after__ values then become available at 10:00 UTC
     on 09/09/2022.
 
     If regime is not specificied, the most up-to-date GSP yield is returned.
@@ -138,17 +146,22 @@ async def get_all_available_forecasts(
     historic: Optional[bool] = False,
     session: Session = Depends(get_session),
 ) -> ManyForecasts:
-    """### Get the latest information for all available forecasts for all GSP's
+    """### Get the latest information for ALL available forecasts for ALL GSPs
 
-    This route returns forecasts from all available GSP's with an option to normalize 
-    the forecasts by GSP installed capacity (installedCapacityMw).
+    The return object contains a forecast object and system details for all National Grid GSPs. 
+    
+    This request may take a longer time to load because a lot of data is being pulled from the database.
+
+    This route returns forecasts objects from all available GSPs with an option to normalize 
+    the forecasts by GSP installed capacity (installedCapacityMw). Normalization returns a decimal value equal 
+    to _expectedPowerGenerationMegawatts_ divided by __installedCapacityMw__ for the GSP. 
 
     There is also the option to pull forecast history from yesterday.
 
 
     #### Parameters
-    - normalize: boolean based on forecasts by GSP installed megawatt capacity
-    - historic: boolean => TRUE returns the forecasts of yesterday along with today's forecasts
+    - normalize: boolean => TRUE returns a value for _expectedPowerGenerationNormalized__, which in decimals is the percent of __installedCapacityMw__ (installed PV megawatt capacity) being forecasted / FALSE returns "null"
+    - historic: boolean => TRUE returns the forecasts of yesterday along with today's forecasts for all GSPs
     """
 
     logger.info(f"Get forecasts for all gsps. The options are  {normalize=} and {historic=}")
@@ -168,8 +181,11 @@ async def get_nationally_aggregated_forecasts(session: Session = Depends(get_ses
 ) -> Forecast:
     """### Returns a national aggregate solar PV energy forecast
 
-    This route aggregrates data from all GSP forecasts and creates 8-hour nowcast of national solar PV
-    energy generation(expectedPowerGenerationMegawatts) in 30-minute intervals (timeTarget).
+    The return object is a forecast object. 
+
+    This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy generation forecast  in 30-minute interval for all of GB.
+
+    See __Forecast__ and __ForecastValue__ schemas for metadata descriptions. 
 
     """
 
@@ -183,10 +199,10 @@ async def get_gsp_boundaries() -> dict:
 
     This route is still under construction...
 
-    [This is a wrapper around the dataset](https://data.nationalgrideso.com/system
-    gis-boundaries-for-gb-grid-supply-points).
+    [This is a wrapper around the dataset](https://data.nationalgrideso.com/systemgis-boundaries-for-gb-grid-supply-points).
 
-    Returns an object that is in EPSG:4326 (ie. latitude & longitude coordinates)
+    Returns an object that is in EPSG:4326 (ie. latitude & longitude coordinates).
+
     """
 
     logger.info("Getting all GSP boundaries")
@@ -202,29 +218,20 @@ async def get_gsp_boundaries() -> dict:
 async def get_systems(
     session: Session = Depends(get_session), gsp_id: Optional[int] = None
 ) -> List[Location]:
-    """### Get system details for a single GSP or all GSP's
+    """### Get system details for a single GSP or all GSPs
 
     Returns an object with the system details of a given GSP using the 
     gsp_id parameter.
-    
-    This object is the same as the initial object returned 
-    by the __Get Forecasts for a Specific GSP__ request.
 
     Provide one gsp_id to return system details for that GSP, otherwise details for ALL 
     grid systems will be returned.
 
+    Please see __Location__ schema for metadata details. 
+
     #### Parameters
     - gsp_id: gsp_id of the requested system
-    - NB: If no parameter is entered, system details for all 300+ GSP's are returned.
+    - NB: If no parameter is entered, system details for all 300+ GSPs are returned.
 
-    #### Metadata
-    - label
-    - gspId
-    - gspName
-    - gspGroup
-    - regtionName
-    - installedCapacityMw
-    - rmMode
     """
 
     logger.info(f"Get GSP systems for {gsp_id=}")

--- a/src/main.py
+++ b/src/main.py
@@ -25,21 +25,21 @@ still under development.
 
 #### General Overview
 
-__Nowcasting__ essentially means __forecasting for the next few hours__. 
-OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for the UK’s 
-National Grid ESO (electricity system operator). National Grid runs more than 300 grid supply points (GSP’s), 
-which are regionally located throughout the country. Every 30 minutes at the level of the GSP, OCF's 
+__Nowcasting__ essentially means __forecasting for the next few hours__.
+OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for the UK’s
+National Grid ESO (electricity system operator). National Grid runs more than 300 grid supply points (GSP’s),
+which are regionally located throughout the country. Every 30 minutes at the level of the GSP, OCF's
 Nowcasting App synthesizes live PV data, numeric weather predictions (nwp), satellite data (looking at cloud
 cover), as well as GSP data to create a forecast for how many megawatts of PV energy will likely be generated
 at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to reduce the amount of
-spinning reserves they need to run, ultimately reducing carbon emmisions. 
+spinning reserves they need to run, ultimately reducing carbon emmisions.
 
 In order to get started with reading the API’s forecast objects, it might be helpful to know that GSP's are
 referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); regionName (ex. Fiddlers Ferry).
 The API provides information on when input data was last updated as well as a specific GSP's installed PV
-megawatt capacity. 
+megawatt capacity.
 
-You'll find more detailed information for each route in the documentation below. 
+You'll find more detailed information for each route in the documentation below.
 
 If you have any questions, please don't hesitate to get in touch. And if you're interested in contributing to
 our open source project feel free to join us!
@@ -95,8 +95,8 @@ app.include_router(status_router, prefix=f"{v0_route}")
 @app.get("/")
 async def get_api_information():
     """### Get basic information about the Nowcasting API
-    
-    This returns an object containing the basic information about the Nowcasting API.  
+
+    This returns an object containing the basic information about the Nowcasting API.
 
     #### Metadata
     - title

--- a/src/main.py
+++ b/src/main.py
@@ -26,24 +26,29 @@ Nowcasting API is still under development.
 #### General Overview
 
 __Nowcasting__ essentially means __forecasting for the next few hours__.
-OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for 
+OCF has built a predictive model that nowcasts solar energy generation for 
 the UK’s National Grid ESO (electricity system operator). National Grid runs more than 
-300 grid supply points (GSP’s), which are regionally located throughout the country. 
-Every 30 minutes at the level of the GSP, OCF's Nowcasting App synthesizes live PV data, 
-numeric weather predictions (nwp), satellite data (looking at cloud cover), as well as GSP 
-data to create a forecast for how many megawatts of PV energy will likely be generated
-at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to 
-reduce the amount of spinning reserves they need to run, ultimately reducing carbon emmisions.
+300 [grid supply points](https://data.nationalgrideso.com/system/gis-boundaries-for-gb-grid-supply-points)
+(GSP’s), which are regionally located throughout the country. OCF's Nowcasting App synthesizes real-time PV
+data, numeric weather predictions (nwp), satellite imagery (looking at cloud cover), as well as GSP data to
+create a forecast how many megawatts of solar energy will likely be generated at a given GSP. 
+
+Here are key aspects of the solar forecasts:
+- Forecasts are produced in 30-minute time steps, from the next half hour out to eight hours ahead.
+- The geographic extent is all of Great Britain (GB). 
+- Forecasts are produced at the GB National and regional level (using GSPs)
+
+OCF's incredibly accurate, short-term forecasts allow National Grid to reduce the amount of spinning reserves they need to run at any given moment, ultimately reducing carbon emmisions.
 
 In order to get started with reading the API’s forecast objects, it might be helpful to 
-know that GSP's are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); 
+know that GSP's are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); gspGroup (ex. )
 regionName (ex. Fiddlers Ferry). The API provides information on when input data was last updated 
-as well as a specific GSP's installed PV megawatt capacity.
+as well as the installed PV megawatt capacity (installedCapacityMw) of each individual GSP. 
 
 You'll find more detailed information for each route in the documentation below.
 
 If you have any questions, please don't hesitate to get in touch. 
-And if you're interested in contributing to our open source project feel free to join us!
+And if you're interested in contributing to our open source project, feel free to join us!
 """
 app = FastAPI(
     title="Nowcasting API",

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,20 @@ logger = logging.getLogger(__name__)
 
 version = "0.2.22"
 description = """
-# The Nowcasting API is still under development.
+As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the Nowcasting API is still under development.
+
+#### General Overview
+
+__Nowcasting__ essentially means __forecasting for the next few hours__. 
+OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for the UK’s National Grid ESO (electricity system operator). National Grid runs more than 300 grid supply points (GSP’s), which are regionally located throughout the country. Every 30 minutes at the level of the GSP, OCF's Nowcasting App synthesises live PV data, numeric weather predictions (nwp), satellite data (looking at cloud cover), as well as GSP data to create a forecast for how many megawatts of PV energy will likely be generated at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to reduce the amount of spinning reserves they need to run, ultimately reducing carbon emmisions. 
+
+In order to get started with reading the API’s forecast objects, it might be helpful to know that GSP's are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); regionName (ex. Fiddlers Ferry). The API provides information on when input data was last updated as well as a specific GSP's installed PV megawatt capacity. 
+
+You'll find more detailed information for each route in the documentation below. 
+
+If you have any questions, please don't hesitate to get in touch. And feel free to join us!
+
+
 """
 app = FastAPI(
     title="Nowcasting API",
@@ -72,8 +85,7 @@ app.include_router(status_router, prefix=f"{v0_route}")
 
 @app.get("/")
 async def get_api_information():
-    """Get information about the API itself Get information about the API
-    information about the api
+    """Get information about the API itself 
     """
 
     logger.info("Route / has be called")

--- a/src/main.py
+++ b/src/main.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 version = "0.2.22"
 description = """
-As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the Nowcasting API is
-still under development.
+As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the 
+Nowcasting API is still under development.
 
 #### General Overview
 

--- a/src/main.py
+++ b/src/main.py
@@ -31,19 +31,19 @@ the UK’s National Grid ESO (electricity system operator). National Grid runs m
 300 [grid supply points](https://data.nationalgrideso.com/system/gis-boundaries-for-gb-grid-supply-points)
 (GSP’s), which are regionally located throughout the country. OCF's Nowcasting App synthesizes real-time PV
 data, numeric weather predictions (nwp), satellite imagery (looking at cloud cover), as well as GSP data to
-create a forecast how many megawatts of solar energy will likely be generated at a given GSP. 
+forecast how much solar energy will generated for a given GSP. 
 
 Here are key aspects of the solar forecasts:
-- Forecasts are produced in 30-minute time steps, from the next half hour out to eight hours ahead.
+- Forecasts are produced in 30-minute time steps, projecting GSP yields out to eight hours ahead.
 - The geographic extent is all of Great Britain (GB). 
-- Forecasts are produced at the GB National and regional level (using GSPs)
+- Forecasts are produced at the GB National and regional level (using GSPs).
 
 OCF's incredibly accurate, short-term forecasts allow National Grid to reduce the amount of spinning reserves they need to run at any given moment, ultimately reducing carbon emmisions.
 
 In order to get started with reading the API’s forecast objects, it might be helpful to 
-know that GSP's are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); gspGroup (ex. )
+know that GSPs are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); gspGroup (ex. )
 regionName (ex. Fiddlers Ferry). The API provides information on when input data was last updated 
-as well as the installed PV megawatt capacity (installedCapacityMw) of each individual GSP. 
+as well as the installed photovoltaic (PV) megawatt capacity (installedCapacityMw) of each individual GSP. 
 
 You'll find more detailed information for each route in the documentation below.
 
@@ -102,13 +102,7 @@ app.include_router(status_router, prefix=f"{v0_route}")
 async def get_api_information():
     """### Get basic information about the Nowcasting API
 
-    This returns an object containing the basic information about the Nowcasting API.
-
-    #### Metadata
-    - title
-    - version
-    - description
-    - documentation
+    The object returned contains basic information about the Nowcasting API.
 
     """
 

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 version = "0.2.22"
 description = """
-The Nowcasting API is still under development.
+# The Nowcasting API is still under development.
 """
 app = FastAPI(
     title="Nowcasting API",
@@ -72,7 +72,9 @@ app.include_router(status_router, prefix=f"{v0_route}")
 
 @app.get("/")
 async def get_api_information():
-    """Get information about the API itself"""
+    """Get information about the API itself Get information about the API
+    information about the api
+    """
 
     logger.info("Route / has be called")
 

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,7 @@ In order to get started with reading the API’s forecast objects, it might be h
 
 You'll find more detailed information for each route in the documentation below. 
 
-If you have any questions, please don't hesitate to get in touch. And feel free to join us!
+If you have any questions, please don't hesitate to get in touch. And if you're interested in contributing to our open source project feel free to join us!
 
 
 """

--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,16 @@ app.include_router(status_router, prefix=f"{v0_route}")
 
 @app.get("/")
 async def get_api_information():
-    """Get information about the API itself 
+    """### Get basic information about the Nowcasting API
+    
+    This returns an object containing the basic information about the Nowcasting API.  
+
+    #### Metadata
+    - title
+    - version
+    - description
+    - documentation
+
     """
 
     logger.info("Route / has be called")

--- a/src/main.py
+++ b/src/main.py
@@ -20,20 +20,29 @@ logger = logging.getLogger(__name__)
 
 version = "0.2.22"
 description = """
-As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the Nowcasting API is still under development.
+As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the Nowcasting API is
+still under development.
 
 #### General Overview
 
 __Nowcasting__ essentially means __forecasting for the next few hours__. 
-OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for the UK’s National Grid ESO (electricity system operator). National Grid runs more than 300 grid supply points (GSP’s), which are regionally located throughout the country. Every 30 minutes at the level of the GSP, OCF's Nowcasting App synthesises live PV data, numeric weather predictions (nwp), satellite data (looking at cloud cover), as well as GSP data to create a forecast for how many megawatts of PV energy will likely be generated at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to reduce the amount of spinning reserves they need to run, ultimately reducing carbon emmisions. 
+OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for the UK’s 
+National Grid ESO (electricity system operator). National Grid runs more than 300 grid supply points (GSP’s), 
+which are regionally located throughout the country. Every 30 minutes at the level of the GSP, OCF's 
+Nowcasting App synthesizes live PV data, numeric weather predictions (nwp), satellite data (looking at cloud
+cover), as well as GSP data to create a forecast for how many megawatts of PV energy will likely be generated
+at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to reduce the amount of
+spinning reserves they need to run, ultimately reducing carbon emmisions. 
 
-In order to get started with reading the API’s forecast objects, it might be helpful to know that GSP's are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); regionName (ex. Fiddlers Ferry). The API provides information on when input data was last updated as well as a specific GSP's installed PV megawatt capacity. 
+In order to get started with reading the API’s forecast objects, it might be helpful to know that GSP's are
+referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); regionName (ex. Fiddlers Ferry).
+The API provides information on when input data was last updated as well as a specific GSP's installed PV
+megawatt capacity. 
 
 You'll find more detailed information for each route in the documentation below. 
 
-If you have any questions, please don't hesitate to get in touch. And if you're interested in contributing to our open source project feel free to join us!
-
-
+If you have any questions, please don't hesitate to get in touch. And if you're interested in contributing to
+our open source project feel free to join us!
 """
 app = FastAPI(
     title="Nowcasting API",

--- a/src/main.py
+++ b/src/main.py
@@ -26,23 +26,24 @@ still under development.
 #### General Overview
 
 __Nowcasting__ essentially means __forecasting for the next few hours__.
-OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for the UK’s
-National Grid ESO (electricity system operator). National Grid runs more than 300 grid supply points (GSP’s),
-which are regionally located throughout the country. Every 30 minutes at the level of the GSP, OCF's
-Nowcasting App synthesizes live PV data, numeric weather predictions (nwp), satellite data (looking at cloud
-cover), as well as GSP data to create a forecast for how many megawatts of PV energy will likely be generated
-at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to reduce the amount of
-spinning reserves they need to run, ultimately reducing carbon emmisions.
+OCF has built a predictive model that nowcasts solar photovoltaic (PV) energy input for 
+the UK’s National Grid ESO (electricity system operator). National Grid runs more than 
+300 grid supply points (GSP’s), which are regionally located throughout the country. 
+Every 30 minutes at the level of the GSP, OCF's Nowcasting App synthesizes live PV data, 
+numeric weather predictions (nwp), satellite data (looking at cloud cover), as well as GSP 
+data to create a forecast for how many megawatts of PV energy will likely be generated
+at a given GSP. These incredibly accurate, short-term forecasts allow National Grid to 
+reduce the amount of spinning reserves they need to run, ultimately reducing carbon emmisions.
 
-In order to get started with reading the API’s forecast objects, it might be helpful to know that GSP's are
-referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); regionName (ex. Fiddlers Ferry).
-The API provides information on when input data was last updated as well as a specific GSP's installed PV
-megawatt capacity.
+In order to get started with reading the API’s forecast objects, it might be helpful to 
+know that GSP's are referenced in the following ways:  gspId (ex. 122); gspName (ex. FIDF_1); 
+regionName (ex. Fiddlers Ferry). The API provides information on when input data was last updated 
+as well as a specific GSP's installed PV megawatt capacity.
 
 You'll find more detailed information for each route in the documentation below.
 
-If you have any questions, please don't hesitate to get in touch. And if you're interested in contributing to
-our open source project feel free to join us!
+If you have any questions, please don't hesitate to get in touch. 
+And if you're interested in contributing to our open source project feel free to join us!
 """
 app = FastAPI(
     title="Nowcasting API",

--- a/src/status.py
+++ b/src/status.py
@@ -19,7 +19,7 @@ async def get_status(session: Session = Depends(get_session)) -> Status:
 
     (might be good to explain this a bit more)
 
-     """
+    """
 
     logger.debug("Get status")
     return get_latest_status_from_database(session=session)

--- a/src/status.py
+++ b/src/status.py
@@ -15,7 +15,11 @@ router = APIRouter()
 
 @router.get("/status", response_model=Status)
 async def get_status(session: Session = Depends(get_session)) -> Status:
-    """Get the status of the solar forecasts"""
+    """### Get status for solar forecasts
+
+    (might be good to explain this a bit more)
+
+     """
 
     logger.debug("Get status")
     return get_latest_status_from_database(session=session)


### PR DESCRIPTION
# Pull Request

## Description

Successfully removed normalize option on get all forecasts route.
I did not yet test the changes I made to the code for the get request setting normalize to TRUE as a default

After googling and looking in the FastAPI documentation, I made a guess as to were to set "normalize" to true and tried something like this: 

`forecasts = get_all_gsp_ids_latest_forecast(
            session=session,
            start_target_time=yesterday_start_datetime,
            preload_children=True,
            historic=True,
            normalize=True,
        )`

It'll probably make more sense in the code. 

Fixes #142

## How Has This Been Tested?

I removed the field  on the Get All Available Forecasts route that set "normalize" as an optional boolean. 
I did not test the changes  to the get request using the actual database. 

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
