### PR TITLE
at forecast horizon minutes to national route

### DIFF
--- a/src/national.py
+++ b/src/national.py
@@ -27,7 +27,9 @@ async def get_national_forecast(
     only_forecast_values: Optional[bool] = False,
     forecast_horizon_minutes: Optional[int] = None,
 ) -> Union[Forecast, List[ForecastValue]]:
-    """###     This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy
+    """ Get the National Forecast
+
+    This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy
     generation forecast  in 30-minute interval for all of GB.
 
     1. Get __recent solar forecast__ for the UK for today and yesterday

--- a/src/national.py
+++ b/src/national.py
@@ -1,15 +1,16 @@
 """National API routes"""
 import logging
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends
-from nowcasting_datamodel.models import Forecast, GSPYield
+from nowcasting_datamodel.models import Forecast, GSPYield, ForecastValue
 from sqlalchemy.orm.session import Session
 
 from database import (
-    get_forecasts_for_a_specific_gsp_from_database,
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
+    get_latest_forecast_values_for_a_specific_gsp_from_database,
+    get_forecasts_for_a_specific_gsp_from_database
 )
 
 logger = logging.getLogger(__name__)
@@ -19,35 +20,76 @@ router = APIRouter()
 NationalYield = GSPYield
 
 
-@router.get("/forecast", response_model=Forecast)
-async def get_nationally_aggregated_forecasts(
+@router.get("/forecast", response_model=Union[Forecast, List[ForecastValue]])
+async def get_national_forecast(
     session: Session = Depends(get_session),
     historic: Optional[bool] = False,
-) -> Forecast:
-    """### Returns a national aggregate solar PV energy forecast
-
-    The return object is a forecast object.
-
-    This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy
+    only_forecast_values: Optional[bool] = False,
+    forecast_horizon_minutes: Optional[int] = None,
+) -> Union[Forecast, List[ForecastValue]]:
+    """###     This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy
     generation forecast  in 30-minute interval for all of GB.
 
-    See __Forecast__ and __ForecastValue__ schemas for metadata descriptions.
+    1. Get __recent solar forecast__ for the UK for today and yesterday
+    with system details.
+        - The return object is a solar forecast with forecast details.
+        -The forecast object is returned with expected megawatt generation for the UK
+        for the upcoming 8 hours at every 30-minute interval (targetTime).
+        - Set __only_forecast_values__ ==> FALSE
+        - Setting __historic__ parameter to TRUE returns an object with data
+        from yesterday and today
 
-    params:
-        historic: boolean => TRUE returns yesterday's forecasts in addition to today's forecast
+    2. Get __ONLY__ forecast values for solar national forecast.
+        - Set __only_forecast_values__ to TRUE
+        - Setting a __forecast_horizon_minutes__ parameter retrieves the latest forecast
+        a given set of minutes before the target time.
+        - Return object is a simplified forecast object with __targetTimes__ and
+        __expectedPowerGenerationMegawatts__ at 30-minute intervals.
+        - NB: __historic__ parameter __will not__ work when __only_forecast_values__= TRUE
+
+    Please see the __Forecast__ and __ForecastValue__ schema below for full metadata details.
+
+    #### Parameters
+    - historic: boolean => TRUE returns yesterday's forecasts in addition to today's forecast
+    - only_forecast_values => TRUE returns solar national forecast values
+    - forecast_horizon_minutes: optional forecast horizon in minutes (ex. 35 returns
+    the latest forecast made 35 minutes before the target time)
 
     """
 
     logger.debug("Get national forecasts")
-    national_forecast = get_forecasts_for_a_specific_gsp_from_database(
-        session=session, historic=historic, gsp_id=0
-    )
 
-    logger.debug(
-        f"Got national forecasts with {len(national_forecast.forecast_values)} forecast values"
-    )
+    if not only_forecast_values:
+        logger.debug(f'{"Getting forecast."}')
+        full_forecast = get_forecasts_for_a_specific_gsp_from_database(
+            session=session,
+            gsp_id=0,
+            historic=historic,
+        )
 
-    return national_forecast
+        logger.debug(f"Got forecast.")
+
+        full_forecast.normalize()
+
+        logger.debug(f'{"Normalized forecast."}')
+
+
+        logger.debug(
+            f"Got national forecasts with {len(full_forecast.forecast_values)} forecast values"
+        )
+        return full_forecast
+
+    else:
+
+        national_forecast_values = get_latest_forecast_values_for_a_specific_gsp_from_database(
+            session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
+        )
+
+        logger.debug(
+            f"Got national forecasts with {len(national_forecast_values)} forecast values"
+        )
+
+    return national_forecast_values
 
 
 # corresponds to API route /v0/solar/GB/national/pvlive/, getting PV_Live NationalYield for GB

--- a/src/national.py
+++ b/src/national.py
@@ -3,14 +3,14 @@ import logging
 from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends
-from nowcasting_datamodel.models import Forecast, GSPYield, ForecastValue
+from nowcasting_datamodel.models import Forecast, ForecastValue, GSPYield
 from sqlalchemy.orm.session import Session
 
 from database import (
+    get_forecasts_for_a_specific_gsp_from_database,
+    get_latest_forecast_values_for_a_specific_gsp_from_database,
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
-    get_latest_forecast_values_for_a_specific_gsp_from_database,
-    get_forecasts_for_a_specific_gsp_from_database,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/national.py
+++ b/src/national.py
@@ -62,18 +62,18 @@ async def get_national_forecast(
     logger.debug("Get national forecasts")
 
     if not only_forecast_values:
-        logger.debug(f'{"Getting forecast."}')
+        logger.debug("Getting forecast.")
         full_forecast = get_forecasts_for_a_specific_gsp_from_database(
             session=session,
             gsp_id=0,
             historic=historic,
         )
 
-        logger.debug(f"Got forecast.")
+        logger.debug("Got forecast.")
 
         full_forecast.normalize()
 
-        logger.debug(f'{"Normalized forecast."}')
+        logger.debug("Normalized forecast.")
 
         logger.debug(
             f"Got national forecasts with {len(full_forecast.forecast_values)} forecast values"

--- a/src/national.py
+++ b/src/national.py
@@ -27,7 +27,7 @@ async def get_national_forecast(
     only_forecast_values: Optional[bool] = False,
     forecast_horizon_minutes: Optional[int] = None,
 ) -> Union[Forecast, List[ForecastValue]]:
-    """ Get the National Forecast
+    """Get the National Forecast
 
     This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy
     generation forecast  in 30-minute interval for all of GB.

--- a/src/national.py
+++ b/src/national.py
@@ -10,7 +10,7 @@ from database import (
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
     get_latest_forecast_values_for_a_specific_gsp_from_database,
-    get_forecasts_for_a_specific_gsp_from_database
+    get_forecasts_for_a_specific_gsp_from_database,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,6 @@ async def get_national_forecast(
 
         logger.debug(f'{"Normalized forecast."}')
 
-
         logger.debug(
             f"Got national forecasts with {len(full_forecast.forecast_values)} forecast values"
         )
@@ -85,9 +84,7 @@ async def get_national_forecast(
             session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
         )
 
-        logger.debug(
-            f"Got national forecasts with {len(national_forecast_values)} forecast values"
-        )
+        logger.debug(f"Got national forecasts with {len(national_forecast_values)} forecast values")
 
     return national_forecast_values
 

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from nowcasting_datamodel.fake import make_fake_national_forecast
-from nowcasting_datamodel.models import Forecast, GSPYield, Location, LocationSQL
+from nowcasting_datamodel.models import Forecast, ForecastValue, GSPYield, Location, LocationSQL
 from nowcasting_datamodel.update import update_all_forecast_latest
 
 from database import get_session
@@ -29,6 +29,23 @@ def test_read_latest_national(db_session):
     _ = Forecast(**response.json())
 
 
+def test_read_latest_national_historic_forecast_vallue(db_session):
+    """Check main solar/GB/national/forecast route works"""
+
+    forecast = make_fake_national_forecast(
+        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
+    )
+    db_session.add(forecast)
+    update_all_forecast_latest(forecasts=[forecast], session=db_session)
+
+    app.dependency_overrides[get_session] = lambda: db_session
+
+    response = client.get("/v0/solar/GB/national/forecast/?only_forecast_values=True")
+    assert response.status_code == 200
+
+    _ = [ForecastValue(**f) for f in response.json()]
+
+
 def test_read_latest_national_historic(db_session):
     """Check main solar/GB/national/forecast route works"""
 
@@ -41,7 +58,6 @@ def test_read_latest_national_historic(db_session):
     app.dependency_overrides[get_session] = lambda: db_session
 
     response = client.get("/v0/solar/GB/national/forecast/?historic=True")
-    print(response.json())
     assert response.status_code == 200
 
     _ = Forecast(**response.json())


### PR DESCRIPTION
# Pull Request

## Description

add option for 'forecasting horizon minutes' to national routes.

new routes are:
![Screenshot 2022-09-21 at 10 15 45](https://user-images.githubusercontent.com/34686298/191465886-39123355-be67-4094-b149-cb31d8afe18b.png)

## How Has This Been Tested?

Normal CI + wrote a test + uses database function which is tested fully

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
