### PR TITLE
Switch to redoc with custom theme

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.2.26
+current_version = 0.2.27
 
 [bumpversion:file:src/main.py]
 search = version = "{current_version}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 # copy files over
-COPY ./src /app/src
+# COPY ./src /app/src
 COPY ./requirements.txt /app/requirements.txt
 
 # set working directory
 WORKDIR /app
 
 # install requirements
+RUN apt-get update -y
+RUN apt-get install -y gdal-bin libgdal-dev g++
 RUN pip install -U pip
 RUN pip install -r requirements.txt
 RUN apt-get update && apt-get install -y git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,10 @@ services:
       - "5432:5432"
 
   api:
-    #    build:
-    #      context: .
-    #      dockerfile: Dockerfile
-    image: openclimatefix/nowcasting_api:0.1.7
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # image: openclimatefix/nowcasting_api:0.1.7
     container_name: nowcasting_api
     command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "80"]
     ports:
@@ -22,3 +22,7 @@ services:
     environment:
       - DB_URL=sqlite:///test.db
       - DB_URL_PV=sqlite:///test.db
+    volumes:
+      - type: bind
+        source: ./src
+        target: /app/src

--- a/src/main.py
+++ b/src/main.py
@@ -129,11 +129,11 @@ async def redoc_html():
     """### Render ReDoc with custom theme options included"""
     return get_redoc_html_with_theme(
         title=title,
-        theme={}
     ) 
 
 # OpenAPI (ReDoc) custom theme
 def custom_openapi():
+    """ Make custom redoc theme"""
     if app.openapi_schema:
         return app.openapi_schema
     openapi_schema = get_openapi(

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,7 @@ You'll find more detailed information for each route in the documentation below.
 If you have any questions, please don't hesitate to get in touch.
 And if you're interested in contributing to our open source project, feel free to join us!
 """
-app = FastAPI(docs_url=None, redoc_url=None)
+app = FastAPI(docs_url="/swagger", redoc_url=None)
 
 origins = os.getenv("ORIGINS", "https://app.nowcasting.io").split(",")
 app.add_middleware(

--- a/src/main.py
+++ b/src/main.py
@@ -132,9 +132,10 @@ async def redoc_html():
         title=title,
     )
 
+
 # OpenAPI (ReDoc) custom theme
 def custom_openapi():
-    """ Make custom redoc theme"""
+    """Make custom redoc theme"""
     if app.openapi_schema:
         return app.openapi_schema
     openapi_schema = get_openapi(

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-version = "0.2.26"
+version = "0.2.27"
 description = """
 As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the
 Nowcasting API is still under development.

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.openapi.utils import get_openapi
-from starlette.responses import HTMLResponse
+from redoc_theme import get_redoc_html_with_theme
 
 from gsp import router as gsp_router
 from national import router as national_router
@@ -63,7 +63,7 @@ You'll find more detailed information for each route in the documentation below.
 If you have any questions, please don't hesitate to get in touch.
 And if you're interested in contributing to our open source project, feel free to join us!
 """
-app = FastAPI()
+app = FastAPI(docs_url=None, redoc_url=None)
 
 origins = os.getenv("ORIGINS", "https://app.nowcasting.io").split(",")
 app.add_middleware(
@@ -123,111 +123,7 @@ async def get_favicon() -> FileResponse:
     """Get favicon"""
     return FileResponse("src/favicon.ico")
 
-def get_redoc_html_with_theme(
-    *,
-    openapi_url: str = "./openapi.json",
-    title: str,
-    redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
-    redoc_favicon_url: str = "/favicon.png",
-    with_google_fonts: bool = True,
-    theme = {}
-) -> HTMLResponse:
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-    <title>{title}</title>
-    <!-- needed for adaptive design -->
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    """
-    if with_google_fonts:
-        html += """
-    <link href="https://fonts.googleapis.com/css?family=Inter:300,400,700" rel="stylesheet">
-    """
-    html += f"""
-    <link rel="shortcut icon" href="{redoc_favicon_url}">
-    <!--
-    ReDoc doesn't change outer page styles
-    -->
-    <style>
-      body {{
-        margin: 0;
-        padding: 0;
-      }}
-    </style>
-    </head>
-    <body>
-    <div id="redoc-container"></div>
-    <noscript>
-        ReDoc requires Javascript to function. Please enable it to browse the documentation.
-    </noscript>
-    <script src="{redoc_js_url}"> </script>
-    <script>
-        Redoc.init("{openapi_url}", """ + """{
-            "theme": {
-                "colors": {
-                    "primary": {
-                        "main": "#f7ba17",
-                        "light": "#ffefc6"
-                    },
-                    "success": {
-                        "main": "rgba(28, 184, 65, 1)",
-                        "light": "#81ec9a",
-                        "dark": "#083312",
-                        "contrastText": "#000"
-                    },
-                    "text": {
-                        "primary": "#14120e",
-                        "secondary": "#4d4d4d"
-                    },
-                    "http": {
-                        "get": "#f7ba17",
-                        "post": "rgba(28, 184, 65, 1)",
-                        "put": "rgba(255, 187, 0, 1)",
-                        "delete": "rgba(254, 39, 35, 1)"
-                    }
-                },
-                "typography": {
-                    "fontSize": "15px",
-                    "fontFamily": "Inter, sans-serif",
-                    "lineHeight": "1.5em",
-                    "headings": {
-                        "fontFamily": "Inter, sans-serif",
-                        "fontWeight": "bold",
-                        "lineHeight": "1.5em"
-                    },
-                    "code": {
-                        "fontWeight": "600",
-                        "color": "rgba(92, 62, 189, 1)",
-                        "wrap": true
-                    },
-                    "links": {
-                        "color": "#086788",
-                        "visited": "#086788",
-                        "hover": "#32343a"
-                    }
-                },
-                "sidebar": {
-                    "width": "300px",
-                    "textColor": "#000000"
-                },
-                "logo": {
-                    "gutter": "10px"
-                },
-                "rightPanel": {
-                    "backgroundColor": "rgba(55, 53, 71, 1)",
-                    "textColor": "#ffffff"
-                }
-            }
-        }""" + f""", document.getElementById('redoc-container'))
-    </script>
-    </body>
-    </html>
-    """
-    return HTMLResponse(html)
-
-@app.get("/newdocs", include_in_schema=False)
+@app.get("/docs", include_in_schema=False)
 async def redoc_html():
     """### Render ReDoc with custom theme options included"""
     return get_redoc_html_with_theme(

--- a/src/main.py
+++ b/src/main.py
@@ -244,8 +244,8 @@ def custom_openapi():
         version=version,
         description=description,
         contact={
-            "name": "Open Climate Fix",
-            "url": "https://openclimatefix.org",
+            "name": "Nowcasting by Open Climate Fix",
+            "url": "https://nowcasting.io",
             "email": "info@openclimatefix.org",
         },
         license_info={

--- a/src/main.py
+++ b/src/main.py
@@ -6,12 +6,12 @@ from datetime import timedelta
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
 from fastapi.openapi.utils import get_openapi
-from redoc_theme import get_redoc_html_with_theme
+from fastapi.responses import FileResponse
 
 from gsp import router as gsp_router
 from national import router as national_router
+from redoc_theme import get_redoc_html_with_theme
 from status import router as status_router
 from system import router as system_router
 

--- a/src/main.py
+++ b/src/main.py
@@ -143,7 +143,7 @@ def get_redoc_html_with_theme(
     """
     if with_google_fonts:
         html += """
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Inter:300,400,700" rel="stylesheet">
     """
     html += f"""
     <link rel="shortcut icon" href="{redoc_favicon_url}">
@@ -166,60 +166,58 @@ def get_redoc_html_with_theme(
     <script>
         Redoc.init("{openapi_url}", """ + """{
             "theme": {
-                "breakpoints": {
-                "small": "10rem",
-                "medium": "40rem",
-                "large": "85rem"
-                },
                 "colors": {
-                "primary": {
-                    "main": "rgba(246, 20, 63, 1)",
-                    "light": "rgba(246, 20, 63, 0.42)"
-                },
-                "success": {
-                    "main": "rgba(28, 184, 65, 1)",
-                    "light": "#81ec9a",
-                    "dark": "#083312",
-                    "contrastText": "#000"
-                },
-                "text": {
-                    "primary": "rgba(0, 0, 0, 1)",
-                    "secondary": "#4d4d4d"
-                },
-                "http": {
-                    "get": "rgba(0, 200, 219, 1)",
-                    "post": "rgba(28, 184, 65, 1)",
-                    "put": "rgba(255, 187, 0, 1)",
-                    "delete": "rgba(254, 39, 35, 1)"
-                }
+                    "primary": {
+                        "main": "#f7ba17",
+                        "light": "#ffefc6"
+                    },
+                    "success": {
+                        "main": "rgba(28, 184, 65, 1)",
+                        "light": "#81ec9a",
+                        "dark": "#083312",
+                        "contrastText": "#000"
+                    },
+                    "text": {
+                        "primary": "#14120e",
+                        "secondary": "#4d4d4d"
+                    },
+                    "http": {
+                        "get": "#f7ba17",
+                        "post": "rgba(28, 184, 65, 1)",
+                        "put": "rgba(255, 187, 0, 1)",
+                        "delete": "rgba(254, 39, 35, 1)"
+                    }
                 },
                 "typography": {
-                "fontSize": "16px",
-                "fontFamily": "Fira Sans, Roboto, sans-serif",
-                "optimizeSpeed": true,
-                "smoothing": "antialiased",
-                "headings": {
-                    "fontWeight": "bold",
-                    "lineHeight": "1em"
-                },
-                "code": {
-                    "fontWeight": "600",
-                    "color": "rgba(92, 62, 189, 1)",
-                    "wrap": true
-                },
-                "links": {
-                    "color": "rgba(246, 20, 63, 1)",
-                    "visited": "rgba(246, 20, 63, 1)",
-                    "hover": "#fa768f"
-                }
+                    "fontSize": "15px",
+                    "fontFamily": "Inter, sans-serif",
+                    "lineHeight": "1.5em",
+                    "headings": {
+                        "fontFamily": "Inter, sans-serif",
+                        "fontWeight": "bold",
+                        "lineHeight": "1.5em"
+                    },
+                    "code": {
+                        "fontWeight": "600",
+                        "color": "rgba(92, 62, 189, 1)",
+                        "wrap": true
+                    },
+                    "links": {
+                        "color": "#086788",
+                        "visited": "#086788",
+                        "hover": "#32343a"
+                    }
                 },
                 "sidebar": {
-                "width": "300px",
-                "textColor": "#000000"
+                    "width": "300px",
+                    "textColor": "#000000"
+                },
+                "logo": {
+                    "gutter": "10px"
                 },
                 "rightPanel": {
-                "backgroundColor": "rgba(55, 53, 71, 1)",
-                "textColor": "#ffffff"
+                    "backgroundColor": "rgba(55, 53, 71, 1)",
+                    "textColor": "#ffffff"
                 }
             }
         }""" + f""", document.getElementById('redoc-container'))

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
+from fastapi.openapi.utils import get_openapi
+from starlette.responses import HTMLResponse
 
 from gsp import router as gsp_router
 from national import router as national_router
@@ -19,6 +21,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+title = "Nowcasting API"
 version = "0.2.27"
 description = """
 As part of Open Climate Fix’s [open source project](https://github.com/openclimatefix), the
@@ -60,20 +63,7 @@ You'll find more detailed information for each route in the documentation below.
 If you have any questions, please don't hesitate to get in touch.
 And if you're interested in contributing to our open source project, feel free to join us!
 """
-app = FastAPI(
-    title="Nowcasting API",
-    version=version,
-    description=description,
-    contact={
-        "name": "Open Climate Fix",
-        "url": "https://openclimatefix.org",
-        "email": "info@openclimatefix.org",
-    },
-    license_info={
-        "name": "MIT License",
-        "url": "https://github.com/openclimatefix/nowcasting_api/blob/main/LICENSE",
-    },
-)
+app = FastAPI()
 
 origins = os.getenv("ORIGINS", "https://app.nowcasting.io").split(",")
 app.add_middleware(
@@ -132,3 +122,145 @@ async def get_api_information():
 async def get_favicon() -> FileResponse:
     """Get favicon"""
     return FileResponse("src/favicon.ico")
+
+def get_redoc_html_with_theme(
+    *,
+    openapi_url: str = "./openapi.json",
+    title: str,
+    redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
+    redoc_favicon_url: str = "/favicon.png",
+    with_google_fonts: bool = True,
+    theme = {}
+) -> HTMLResponse:
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>{title}</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    """
+    if with_google_fonts:
+        html += """
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    """
+    html += f"""
+    <link rel="shortcut icon" href="{redoc_favicon_url}">
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {{
+        margin: 0;
+        padding: 0;
+      }}
+    </style>
+    </head>
+    <body>
+    <div id="redoc-container"></div>
+    <noscript>
+        ReDoc requires Javascript to function. Please enable it to browse the documentation.
+    </noscript>
+    <script src="{redoc_js_url}"> </script>
+    <script>
+        Redoc.init("{openapi_url}", """ + """{
+            "theme": {
+                "breakpoints": {
+                "small": "10rem",
+                "medium": "40rem",
+                "large": "85rem"
+                },
+                "colors": {
+                "primary": {
+                    "main": "rgba(246, 20, 63, 1)",
+                    "light": "rgba(246, 20, 63, 0.42)"
+                },
+                "success": {
+                    "main": "rgba(28, 184, 65, 1)",
+                    "light": "#81ec9a",
+                    "dark": "#083312",
+                    "contrastText": "#000"
+                },
+                "text": {
+                    "primary": "rgba(0, 0, 0, 1)",
+                    "secondary": "#4d4d4d"
+                },
+                "http": {
+                    "get": "rgba(0, 200, 219, 1)",
+                    "post": "rgba(28, 184, 65, 1)",
+                    "put": "rgba(255, 187, 0, 1)",
+                    "delete": "rgba(254, 39, 35, 1)"
+                }
+                },
+                "typography": {
+                "fontSize": "16px",
+                "fontFamily": "Fira Sans, Roboto, sans-serif",
+                "optimizeSpeed": true,
+                "smoothing": "antialiased",
+                "headings": {
+                    "fontWeight": "bold",
+                    "lineHeight": "1em"
+                },
+                "code": {
+                    "fontWeight": "600",
+                    "color": "rgba(92, 62, 189, 1)",
+                    "wrap": true
+                },
+                "links": {
+                    "color": "rgba(246, 20, 63, 1)",
+                    "visited": "rgba(246, 20, 63, 1)",
+                    "hover": "#fa768f"
+                }
+                },
+                "sidebar": {
+                "width": "300px",
+                "textColor": "#000000"
+                },
+                "rightPanel": {
+                "backgroundColor": "rgba(55, 53, 71, 1)",
+                "textColor": "#ffffff"
+                }
+            }
+        }""" + f""", document.getElementById('redoc-container'))
+    </script>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)
+
+@app.get("/newdocs", include_in_schema=False)
+async def redoc_html():
+    """### Render ReDoc with custom theme options included"""
+    return get_redoc_html_with_theme(
+        title=title,
+        theme={}
+    ) 
+
+# OpenAPI (ReDoc) custom theme
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title=title,
+        version=version,
+        description=description,
+        contact={
+            "name": "Open Climate Fix",
+            "url": "https://openclimatefix.org",
+            "email": "info@openclimatefix.org",
+        },
+        license_info={
+            "name": "MIT License",
+            "url": "https://github.com/openclimatefix/nowcasting_api/blob/main/LICENSE",
+        },
+        routes=app.routes,
+    )
+    openapi_schema["info"]["x-logo"] = {
+        "url": "https://www.nowcasting.io/nowcasting.svg"
+    }
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi

--- a/src/redoc_theme.py
+++ b/src/redoc_theme.py
@@ -1,4 +1,6 @@
+""" Redoc theme functions """
 from starlette.responses import HTMLResponse
+
 
 def get_redoc_html_with_theme(
     *,
@@ -7,8 +9,17 @@ def get_redoc_html_with_theme(
     redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
     redoc_favicon_url: str = "/favicon.png",
     with_google_fonts: bool = True,
-    theme = {}
 ) -> HTMLResponse:
+    """
+    Get redoc htm theme
+
+    :param openapi_url: URL for open api
+    :param title: The title of the app
+    :param redoc_js_url: TODO
+    :param redoc_favicon_url: favicon icon locayion
+    :param with_google_fonts: option to sue google fonts
+    :return:
+    """
     html = f"""
     <!DOCTYPE html>
     <html>

--- a/src/redoc_theme.py
+++ b/src/redoc_theme.py
@@ -111,7 +111,7 @@ def get_redoc_html_with_theme(
                 }
             }
         }"""
-        + f""", document.getElementById('redoc-container'))
+        + """, document.getElementById('redoc-container'))
     </script>
     </body>
     </html>

--- a/src/redoc_theme.py
+++ b/src/redoc_theme.py
@@ -1,0 +1,105 @@
+from starlette.responses import HTMLResponse
+
+def get_redoc_html_with_theme(
+    *,
+    openapi_url: str = "./openapi.json",
+    title: str,
+    redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
+    redoc_favicon_url: str = "/favicon.png",
+    with_google_fonts: bool = True,
+    theme = {}
+) -> HTMLResponse:
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>{title}</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    """
+    if with_google_fonts:
+        html += """
+    <link href="https://fonts.googleapis.com/css?family=Inter:300,400,700" rel="stylesheet">
+    """
+    html += f"""
+    <link rel="shortcut icon" href="{redoc_favicon_url}">
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {{
+        margin: 0;
+        padding: 0;
+      }}
+    </style>
+    </head>
+    <body>
+    <div id="redoc-container"></div>
+    <noscript>
+        ReDoc requires Javascript to function. Please enable it to browse the documentation.
+    </noscript>
+    <script src="{redoc_js_url}"> </script>
+    <script>
+        Redoc.init("{openapi_url}", """ + """{
+            "theme": {
+                "colors": {
+                    "primary": {
+                        "main": "#f7ba17",
+                        "light": "#ffefc6"
+                    },
+                    "success": {
+                        "main": "rgba(28, 184, 65, 1)",
+                        "light": "#81ec9a",
+                        "dark": "#083312",
+                        "contrastText": "#000"
+                    },
+                    "text": {
+                        "primary": "#14120e",
+                        "secondary": "#4d4d4d"
+                    },
+                    "http": {
+                        "get": "#f7ba17",
+                        "post": "rgba(28, 184, 65, 1)",
+                        "put": "rgba(255, 187, 0, 1)",
+                        "delete": "rgba(254, 39, 35, 1)"
+                    }
+                },
+                "typography": {
+                    "fontSize": "15px",
+                    "fontFamily": "Inter, sans-serif",
+                    "lineHeight": "1.5em",
+                    "headings": {
+                        "fontFamily": "Inter, sans-serif",
+                        "fontWeight": "bold",
+                        "lineHeight": "1.5em"
+                    },
+                    "code": {
+                        "fontWeight": "600",
+                        "color": "rgba(92, 62, 189, 1)",
+                        "wrap": true
+                    },
+                    "links": {
+                        "color": "#086788",
+                        "visited": "#086788",
+                        "hover": "#32343a"
+                    }
+                },
+                "sidebar": {
+                    "width": "300px",
+                    "textColor": "#000000"
+                },
+                "logo": {
+                    "gutter": "10px"
+                },
+                "rightPanel": {
+                    "backgroundColor": "rgba(55, 53, 71, 1)",
+                    "textColor": "#ffffff"
+                }
+            }
+        }""" + f""", document.getElementById('redoc-container'))
+    </script>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)


### PR DESCRIPTION
# Pull Request

## Description

We'd like to make the public nowcasting docs nicer looking and easier for new users to read. By moving from Swagger UI to ReDoc (also included by default in FastAPI) we get a nicer UI, with a sidebar nav which can have static pages in it in future. This PR is just focused on switching to ReDoc with a custom theme that aligns with our brand.

If we're happy with these new docs, we should change the route from /newdocs to /docs.

Note: I had to made some docker changes to run this repo locally. If docker is used in prod, you may want to throw the commit with those changes away or move them to renamed files for localdev.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
