### PR TITLE
nowcasting_datamodel==1.1.68

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]
 pydantic
 numpy
 requests
-nowcasting_datamodel==1.1.54
+nowcasting_datamodel==1.1.68
 nowcasting_dataset==3.7.12
 sqlalchemy
 psycopg2-binary


### PR DESCRIPTION
# Pull Request

## Description

Update to datamode 1.1.68, biggest change being there are less warnings printed out

Fixes #

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
