### PR TITLE
change default to always load history on /gsp/forecast/all

### DIFF
--- a/src/gsp.py
+++ b/src/gsp.py
@@ -37,7 +37,7 @@ NationalYield = GSPYield
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 async def get_all_available_forecasts(
-    historic: Optional[bool] = False,
+    historic: Optional[bool] = True,
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> ManyForecasts:

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -45,7 +45,7 @@ def test_read_latest_all_gsp(db_session, api_client):
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/gsp/forecast/all/")
+    response = api_client.get("/v0/solar/GB/gsp/forecast/all/?historic=False")
 
     assert response.status_code == 200
 
@@ -66,7 +66,7 @@ def test_read_latest_all_gsp_normalized(db_session, api_client):
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/gsp/forecast/all/?normalize=True")
+    response = api_client.get("/v0/solar/GB/gsp/forecast/all/?historic=False&normalize=True")
 
     assert response.status_code == 200
 


### PR DESCRIPTION
# Pull Request

## Description

Change `forecast/gsp/all` to default `historic=True`, this will help with speed up

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
