### PR TITLE
make sure we dont load national forecast

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -61,6 +61,10 @@ def get_forecasts_from_database(
             preload_children=True,
             historic=True,
         )
+        if forecasts[0].location.gsp_id == 0:
+            # make sure we don't get national forecast here
+            forecasts.pop(0)
+
     else:
         # To speed up read time we only look at the last 12 hours of results, and take floor 30 mins
         yesterday_start_datetime = floor_30_minutes_dt(

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -96,7 +96,7 @@ def test_read_latest_all_gsp_historic(db_session, api_client):
 
     r = ManyForecasts(**response.json())
 
-    assert len(r.forecasts) == 10
+    assert len(r.forecasts) == 9  # dont get national
     assert len(r.forecasts[0].forecast_values) > 50
     assert r.forecasts[0].forecast_values[0].expected_power_generation_megawatts <= 13000
     assert r.forecasts[1].forecast_values[0].expected_power_generation_megawatts <= 10


### PR DESCRIPTION
# Pull Request

## Description

make sure no national forecast when calling all GSPS

## How Has This Been Tested?

Updated tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
