### PR TITLE
upgrade dm, only get gsp cnn results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]
 pydantic
 numpy
 requests
-nowcasting_datamodel==1.3.15
+nowcasting_datamodel==1.3.19
 nowcasting_dataset==3.7.12
 sqlalchemy
 psycopg2-binary

--- a/src/database.py
+++ b/src/database.py
@@ -63,6 +63,7 @@ def get_forecasts_from_database(
             preload_children=True,
             historic=True,
             include_national=False,
+            model_name="cnn",
         )
 
         logger.debug(f"Found {len(forecasts)} forecasts from database")
@@ -78,6 +79,7 @@ def get_forecasts_from_database(
             start_created_utc=yesterday_start_datetime,
             start_target_time=yesterday_start_datetime,
             preload_children=True,
+            model_name="cnn",
         )
 
     # change to pydantic objects

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -16,7 +16,7 @@ from main import app
 def forecasts(db_session):
     """Pytest fixture of 338 fake forecasts"""
     # create
-    f = make_fake_forecasts(gsp_ids=list(range(0, 338)), session=db_session)
+    f = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session)
     db_session.add_all(f)
 
     return f

--- a/src/tests/test_database.py
+++ b/src/tests/test_database.py
@@ -23,7 +23,7 @@ def test_get_forecasts_for_a_specific_gsp_from_database(db_session, forecasts):
 def test_get_gsp_system_all(db_session, forecasts):
     """Check get gsp system works for all systems"""
     a = get_gsp_system(session=db_session)
-    assert len(a) == 338
+    assert len(a) == 10
 
 
 def test_get_gsp_system_one(db_session, forecasts):

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -2,7 +2,6 @@
 from datetime import datetime, timezone
 
 from freezegun import freeze_time
-from nowcasting_datamodel.read.read import get_model
 from nowcasting_datamodel.fake import make_fake_forecasts
 from nowcasting_datamodel.models import (
     Forecast,
@@ -12,6 +11,7 @@ from nowcasting_datamodel.models import (
     LocationWithGSPYields,
     ManyForecasts,
 )
+from nowcasting_datamodel.read.read import get_model
 from nowcasting_datamodel.save.update import update_all_forecast_latest
 
 from database import get_session

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -37,14 +37,14 @@ def test_read_latest_one_gsp(db_session, api_client):
 def test_read_latest_all_gsp(db_session, api_client):
     """Check main solar/GB/gsp/forecast/all route works"""
 
-    model = get_model(session=db_session, name='cnn',version='0.0.1')
+    model = get_model(session=db_session, name="cnn", version="0.0.1")
 
     forecasts = make_fake_forecasts(
         gsp_ids=list(range(0, 10)),
         session=db_session,
         t0_datetime_utc=datetime.now(tz=timezone.utc),
     )
-    [setattr(f,'model',model) for f in forecasts]
+    [setattr(f, "model", model) for f in forecasts]
 
     db_session.add_all(forecasts)
 
@@ -62,14 +62,14 @@ def test_read_latest_all_gsp(db_session, api_client):
 def test_read_latest_all_gsp_normalized(db_session, api_client):
     """Check main solar/GB/gsp/forecast/all normalized route works"""
 
-    model = get_model(session=db_session, name='cnn', version='0.0.1')
+    model = get_model(session=db_session, name="cnn", version="0.0.1")
 
     forecasts = make_fake_forecasts(
         gsp_ids=list(range(0, 10)),
         session=db_session,
         t0_datetime_utc=datetime.now(tz=timezone.utc),
     )
-    [setattr(f, 'model', model) for f in forecasts]
+    [setattr(f, "model", model) for f in forecasts]
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session
@@ -87,7 +87,7 @@ def test_read_latest_all_gsp_normalized(db_session, api_client):
 def test_read_latest_all_gsp_historic(db_session, api_client):
     """Check main solar/GB/gsp/forecast/all historic route works"""
 
-    model = get_model(session=db_session, name='cnn', version='0.0.1')
+    model = get_model(session=db_session, name="cnn", version="0.0.1")
 
     forecasts = make_fake_forecasts(
         gsp_ids=list(range(0, 10)),
@@ -95,7 +95,7 @@ def test_read_latest_all_gsp_historic(db_session, api_client):
         t0_datetime_utc=datetime.now(tz=timezone.utc),
         historic=True,
     )
-    [setattr(f, 'model', model) for f in forecasts]
+    [setattr(f, "model", model) for f in forecasts]
     db_session.add_all(forecasts)
     update_all_forecast_latest(forecasts=forecasts, session=db_session)
 

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timezone
 
 from freezegun import freeze_time
+from nowcasting_datamodel.read.read import get_model
 from nowcasting_datamodel.fake import make_fake_forecasts
 from nowcasting_datamodel.models import (
     Forecast,
@@ -36,11 +37,15 @@ def test_read_latest_one_gsp(db_session, api_client):
 def test_read_latest_all_gsp(db_session, api_client):
     """Check main solar/GB/gsp/forecast/all route works"""
 
+    model = get_model(session=db_session, name='cnn',version='0.0.1')
+
     forecasts = make_fake_forecasts(
         gsp_ids=list(range(0, 10)),
         session=db_session,
         t0_datetime_utc=datetime.now(tz=timezone.utc),
     )
+    [setattr(f,'model',model) for f in forecasts]
+
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session
@@ -57,11 +62,14 @@ def test_read_latest_all_gsp(db_session, api_client):
 def test_read_latest_all_gsp_normalized(db_session, api_client):
     """Check main solar/GB/gsp/forecast/all normalized route works"""
 
+    model = get_model(session=db_session, name='cnn', version='0.0.1')
+
     forecasts = make_fake_forecasts(
         gsp_ids=list(range(0, 10)),
         session=db_session,
         t0_datetime_utc=datetime.now(tz=timezone.utc),
     )
+    [setattr(f, 'model', model) for f in forecasts]
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session
@@ -79,12 +87,15 @@ def test_read_latest_all_gsp_normalized(db_session, api_client):
 def test_read_latest_all_gsp_historic(db_session, api_client):
     """Check main solar/GB/gsp/forecast/all historic route works"""
 
+    model = get_model(session=db_session, name='cnn', version='0.0.1')
+
     forecasts = make_fake_forecasts(
         gsp_ids=list(range(0, 10)),
         session=db_session,
         t0_datetime_utc=datetime.now(tz=timezone.utc),
         historic=True,
     )
+    [setattr(f, 'model', model) for f in forecasts]
     db_session.add_all(forecasts)
     update_all_forecast_latest(forecasts=forecasts, session=db_session)
 


### PR DESCRIPTION
# Pull Request

## Description

Only get CNN results when loading gsp data

Fixes Bug found by @braddf  where both `cnn` and PVnet 2.0 are in https://api-dev.nowcasting.io/v0/solar/GB/gsp/forecast/all/?historic=true&normalize=true and this causes api to fall over

Bonus: speed up tests

## How Has This Been Tested?

- CI test
- adjust tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
