### PR TITLE
allow pvlive values to go back 365

### DIFF
--- a/nowcasting_api/database/database_legacy.py
+++ b/nowcasting_api/database/database_legacy.py
@@ -384,7 +384,7 @@ def get_truth_values_for_a_specific_gsp_from_database(
     :return: list of gsp yields
     """
 
-    start_datetime = get_start_datetime(start_datetime=start_datetime)
+    start_datetime = get_start_datetime(start_datetime=start_datetime, days=365)
 
     return get_gsp_yield(
         session=session,


### PR DESCRIPTION
# Pull Request

## Description

Fix to make sure pvlive data can get data more than 3 days ago. This makes its the same as how much history we can get for national
#494 

## How Has This Been Tested?

- [x] Ci tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
