### PR TITLE
Add Met Office/Sat-only options to National forecast route

### DIFF
--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -57,7 +57,6 @@ model_names_external_to_internal = {
     "pvnet_day_ahead": "pvnet_day_ahead",
     "pvnet_intraday_ecmwf_only": "pvnet_ecmwf",
     "pvnet_intraday_met_office_only": "pvnet-ukv-only",
-    "pvnet_intraday_sat_only": "pvnet-sat-only",
 }
 
 if not is_production:


### PR DESCRIPTION
# Pull Request

## Description

Adds the Met Office-only (and Satellite-only on just development API) to National forecast endpoint.

> [!CAUTION]
> N.B. the Met Office-only model is currently only in `development`, so we should only merge this if and when we are happy / about to release it in `production`.  

Fixes #506 

## How Has This Been Tested?

- [x] Locally with Postman and the Quartz UI

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
