### PR TITLE
Enable sat-only national on all envs

### DIFF
--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -40,7 +40,6 @@ logger = structlog.stdlib.get_logger()
 
 adjust_limit = float(os.getenv("ADJUST_MW_LIMIT", 0.0))
 get_plevels = bool(os.getenv("GET_PLEVELS", True))
-is_production = os.getenv("ENVIRONMENT", "production").lower() == "production"
 
 router = APIRouter(
     tags=["National"],
@@ -57,10 +56,8 @@ model_names_external_to_internal = {
     "pvnet_day_ahead": "pvnet_day_ahead",
     "pvnet_intraday_ecmwf_only": "pvnet_ecmwf",
     "pvnet_intraday_met_office_only": "pvnet-ukv-only",
+    "pvnet_intraday_sat_only": "pvnet-sat-only",
 }
-
-if not is_production:
-    model_names_external_to_internal["pvnet_intraday_sat_only"] = "pvnet-sat-only"
 
 
 class ModelName(str, Enum):
@@ -71,8 +68,7 @@ class ModelName(str, Enum):
     pvnet_day_ahead = "pvnet_day_ahead"
     pvnet_intraday_ecmwf_only = "pvnet_intraday_ecmwf_only"
     pvnet_intraday_met_office_only = "pvnet_intraday_met_office_only"
-    if not is_production:
-        pvnet_intraday_sat_only = "pvnet_intraday_sat_only"
+    pvnet_intraday_sat_only = "pvnet_intraday_sat_only"
 
 
 @router.get(


### PR DESCRIPTION
# Pull Request

## Description

Remove restriction only showing satellite-only National forecast model on development, to allow Production API/UI to serve this model's forecast data.


## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Local with UI running API in dev / prod environments

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
