### PR TITLE
Include user permissions in cache key/func

### DIFF
--- a/nowcasting_api/cache.py
+++ b/nowcasting_api/cache.py
@@ -86,6 +86,10 @@ def cache_response(func):
         session = route_variables.get("session", None)
         user = route_variables.get("user", None)
         request = route_variables.get("request", None)
+        # get permissions from user to save with request
+        if user is not None and hasattr(user, "permissions"):
+            permissions = user.permissions
+            route_variables["permissions"] = permissions
         save_api_call_to_db(session=session, user=user, request=request)
 
         # drop session and user


### PR DESCRIPTION
# Pull Request

## Description

Adding the user permissions to the cache `route_variables` dict to prevent the in-memory cache serving restricted/unrestricted data to users regardless of their permissions. E.g. a user with `intraday` permissions-limited `end_datetime_utc` and therefore forecast values will then cache along with specific permissions, and another user without the permission will request a fresh, unrestricted forecast for the same route.

Fixes #

## How Has This Been Tested?

- [x] Local API with UI and multiple user logins

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
