### PR TITLE
docs: add README deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 [![ease of contribution: medium](https://img.shields.io/badge/ease%20of%20contribution:%20medium-f4900c)](https://github.com/openclimatefix#how-easy-is-it-to-get-involved)
 [![Test Docker image](https://github.com/openclimatefix/uk-pv-national-gsp-api/actions/workflows/test-docker.yaml/badge.svg)](https://github.com/openclimatefix/uk-pv-national-gsp-api/actions/workflows/test-docker.yaml)
 
+> [!WARNING]
+> This API will soon be deprecated in favour of [quartz-api](https://github.com/openclimatefix/quartz-api). Please start planning your migration if you depend on this service.
+
 API for hosting nowcasting solar predictions. This is for GSP and National forecasts in the UK.
 
 We use [FastAPI](https://fastapi.tiangolo.com/).


### PR DESCRIPTION
## Summary
- add a documentation warning block near the top of the README to highlight the upcoming deprecation
- link readers to [quartz-api](https://github.com/openclimatefix/quartz-api) so they know where to migrate

## Rationale
- Issue #511 asked for the same deprecation notice that already appears in pv-site-api; copying the wording here makes the transition plan clear for GSP/National users

## Testing
- not run (documentation-only change)

Fixes #511
