### PR TITLE
fix: pin Redoc cdn script version to v2

### DIFF
--- a/nowcasting_api/redoc_theme.py
+++ b/nowcasting_api/redoc_theme.py
@@ -7,7 +7,7 @@ def get_redoc_html_with_theme(
     *,
     openapi_url: str = "./openapi.json",
     title: str,
-    redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
+    redoc_js_url: str = "https://cdn.redoc.ly/redoc/v2.5.1/bundles/redoc.standalone.js",
     redoc_favicon_url: str = "/favicon.ico",
     with_google_fonts: bool = True,
 ) -> HTMLResponse:


### PR DESCRIPTION
# Pull Request

## Description

Looks like Redoc v3 is about to come out(?) or just about is in General Release as per [the docs](https://redocly.com/docs/redoc), but our CDN link wasn't finding it properly. 

Have now pinned to the latest v2 script version and Redocly's own CDN, also as per the docs.

Fixes #515 

## How Has This Been Tested?

- [x] Locally


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
